### PR TITLE
Allow subclasses to customize error handling

### DIFF
--- a/finch/collection.py
+++ b/finch/collection.py
@@ -30,6 +30,9 @@ class Collection(object):
     def __init__(self, client):
         self.client = client
 
+    def on_error(self, callback, response):
+        callback(errors.HTTPError(response.code))
+
     def all(self, callback):
         self.request_all(callback)
 
@@ -38,7 +41,7 @@ class Collection(object):
 
     def on_all(self, callback, response):
         if response.code >= httplib.BAD_REQUEST:
-            callback(None, errors.HTTPError(response.code))
+            self.on_error(partial(callback, None), response)
             return
 
         if hasattr(self, 'decode'):
@@ -75,7 +78,7 @@ class Collection(object):
 
     def on_get(self, callback, response):
         if response.code >= httplib.BAD_REQUEST:
-            callback(None, errors.HTTPError(response.code))
+            self.on_error(partial(callback, None), response)
             return
 
         result = self.model()
@@ -138,7 +141,7 @@ class Collection(object):
 
     def on_add(self, callback, obj, response):
         if response.code >= httplib.BAD_REQUEST:
-            callback(None, errors.HTTPError(response.code))
+            self.on_error(partial(callback, None), response)
             return
 
         if hasattr(obj, 'decode'):
@@ -165,7 +168,7 @@ class Collection(object):
 
     def on_delete(self, callback, response):
         if response.code >= httplib.BAD_REQUEST:
-            callback(errors.HTTPError(response.code))
+            self.on_error(callback, response)
             return
 
         callback(None)


### PR DESCRIPTION
Hi Jaime,

I'm returning to some code I wrote last year based on Finch and Booby. My code is synchronous, so I basically forked Finch and modified it to suit my purposes. Thanks again for the great libraries; these APIs are really a pleasure to work with.

I offer this suggestion for Finch, based on a pattern that I found quite useful when building a synchronous API client. I suppose my goal is to make the API as similar to yours as possible, and offer programmers an architecture that lets them express the APIs as clearly as possible.

This changeset allows a collection to add semantic error handling which is specific to the API. For example, when a requested entity is not found, an API may return a 404 error with a specific message in the response content. Not all 404's are created equally, however: the API may also return a 404 if the endpoint doesn't exist. So rather than expect the caller to parse and handle the HTTP error object, it's useful to give the collection a chance to do so – and to return a more meaningful error object.

``` py
class NotFound(object):
    def __init__(self, message):
        self.message = message

def on_error(self, callback, response):
    if response.code == httplib.NOT_FOUND and escape.json_decode(response.body) == {'message': 'Could not find resource'}:
        callback(NotFound('Could not find resource'))
    else:
        super(self, Collection).on_error(callback, response)
```

This also allows a collection to log failed requests. For example:

``` py
def on_error(self, callback, response):
    import logging
    logger = logging.getLogger('my_api_client')
    logger.error(response.body)
    callback(errors.HTTPError(response.code))
```

By the way, the code is here: https://github.com/bodylabs/wren , newly extracted from https://github.com/bodylabs/capysule
