### PR TITLE
Allow configuring a base URL

### DIFF
--- a/finch/session.py
+++ b/finch/session.py
@@ -16,6 +16,11 @@
 
 """This module is a wrapper on top of the Tornado's HTTPClient."""
 
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
 from tornado import httpclient
 from tornado import httputil
 
@@ -23,8 +28,9 @@ from finch.auth import HTTPBasicAuth
 
 
 class Session(object):
-    def __init__(self, http_client, auth=None):
+    def __init__(self, http_client, base_url=None, auth=None):
         self.http_client = http_client
+        self.base_url = base_url
 
         if isinstance(auth, tuple):
             self.auth = HTTPBasicAuth(*auth)
@@ -32,6 +38,8 @@ class Session(object):
             self.auth = auth
 
     def fetch(self, url, callback, params=None, **kwargs):
+        if self.base_url is not None:
+            url = urljoin(self.base_url, url)
         if params is not None:
             url = httputil.url_concat(url, params)
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -40,6 +40,19 @@ class TestSession(object):
             callback=CALLBACK
         ))
 
+    def test_when_base_url_set_then_calls_http_client_fetch_with_base_url(self):
+        with Spy(httpclient.HTTPClient()) as http_client:
+            session = Session(http_client, base_url='https://example.com:12345')
+
+        session.fetch('/users?type=json', callback=CALLBACK, params={'is_admin': 'true'})
+
+        assert_that(http_client.fetch, called().with_args(
+            has_properties(
+                url='https://example.com:12345/users?type=json&is_admin=true'
+            ),
+            callback=CALLBACK
+        ))
+
 class TestSessionWithBasicAuth(object):
     def test_when_auth_is_username_and_password_tuple_then_session_uses_basic_auth(self):
         session = Session(Stub(), auth=(u'root', u'toor'))


### PR DESCRIPTION
In a REST client, it's useful to be able to set a base URL, to which resource URLs are relative. In fact I think this is a key feature.

It's particularly useful with APIs where the hostname portion of the base URL includes the account, or when testing an API against multiple endpoints (such as development, staging, and production). By setting the base URL when configuring the client, the collections don't need to concern themselves with it.

Here's an example with a URL based on the account name:

``` py
from finch.session import Session

class Client(Session):
    def __init__(self, http_client, account_name, **kwargs):
        url = "https://%s.api.example.com" % account_name
        super(Client, self).__init__(http_client, base_url=url, **kwargs)
```
